### PR TITLE
support extending addresses from file; init RPC w/ confirmed level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,8 +147,8 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "726535892e8eae7e70657b4c8ea93d26b8553afb1ce617caee529ef96d7dee6c"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
  "synstructure",
 ]
@@ -159,8 +159,8 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2777730b2039ac0f95f093556e61b6d26cebed5393ca6f152717777cec3a42ed"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -199,8 +199,8 @@ version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e805d94e6b5001b651426cf4cd446b1ab5f319d27bab5c644f61de0a804360c"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -321,7 +321,7 @@ dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
  "proc-macro-crate 0.1.5",
- "proc-macro2 1.0.47",
+ "proc-macro2 1.0.69",
  "syn 1.0.102",
 ]
 
@@ -331,8 +331,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5449c28a7b352f2d1e592a8a28bf139bc71afb0764a14f3c02500935d8c44065"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -342,8 +342,8 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdbd5696d8bfa21d53d9fe39a714a18538bad11492a42d066dbbc395fb1951c0"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -405,8 +405,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -536,8 +536,8 @@ checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
 dependencies = [
  "heck",
  "proc-macro-error",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -762,8 +762,8 @@ dependencies = [
  "cc",
  "codespan-reporting",
  "once_cell",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "scratch",
  "syn 1.0.102",
 ]
@@ -780,8 +780,8 @@ version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -898,8 +898,8 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -1003,8 +1003,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8958699f9359f0b04e691a13850d48b7de329138023876d07cbd024c2c820598"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -1015,8 +1015,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eb359f1476bf611266ac1f5355bc14aeca37b299d0ebccc038ee7058891c9cb"
 dependencies = [
  "once_cell",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -1133,8 +1133,8 @@ version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -1652,6 +1652,7 @@ dependencies = [
  "console",
  "dirs",
  "serde",
+ "serde_json",
  "serde_yaml 0.9.13",
  "solana-address-lookup-table-program",
  "solana-client",
@@ -1802,8 +1803,8 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -1875,8 +1876,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce"
 dependencies = [
  "proc-macro-crate 1.2.1",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -2061,8 +2062,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
  "version_check",
 ]
@@ -2073,8 +2074,8 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "version_check",
 ]
 
@@ -2089,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
 ]
@@ -2169,11 +2170,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
- "proc-macro2 1.0.47",
+ "proc-macro2 1.0.69",
 ]
 
 [[package]]
@@ -2547,9 +2548,9 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
 dependencies = [
  "serde_derive",
 ]
@@ -2565,20 +2566,20 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.192"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
- "syn 1.0.102",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.87"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce777b7b150d76b9cf60d28b55f5847135a003f7d7350c6be7a773508ce7d45"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -2941,8 +2942,8 @@ version = "1.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcd7d529da0fa5b3b5ca71645122fc94c2aaf867744497969c109e1d4b8ad02d"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "rustc_version",
  "syn 1.0.102",
 ]
@@ -3193,8 +3194,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ffde9b5b7313629780baca10eaffec7421d53be725c76031ca409a5298705c"
 dependencies = [
  "bs58",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "rustversion",
  "syn 1.0.102",
 ]
@@ -3434,8 +3435,19 @@ version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+dependencies = [
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "unicode-ident",
 ]
 
@@ -3445,8 +3457,8 @@ version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
  "unicode-xid 0.2.4",
 ]
@@ -3514,8 +3526,8 @@ version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -3608,8 +3620,8 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -3698,8 +3710,8 @@ version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
 ]
 
@@ -3893,8 +3905,8 @@ dependencies = [
  "bumpalo",
  "log",
  "once_cell",
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
  "wasm-bindgen-shared",
 ]
@@ -3917,7 +3929,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
- "quote 1.0.21",
+ "quote 1.0.33",
  "wasm-bindgen-macro-support",
 ]
 
@@ -3927,8 +3939,8 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
@@ -4160,8 +4172,8 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
 dependencies = [
- "proc-macro2 1.0.47",
- "quote 1.0.21",
+ "proc-macro2 1.0.69",
+ "quote 1.0.33",
  "syn 1.0.102",
  "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "4.0.17", features = [ "derive" ]}
 console = "0.15.2"
 dirs = "4.0.0"
 serde = "1.0.145"
+serde_json = "1.0.108"
 serde_yaml = "0.9.13"
 solana-address-lookup-table-program = "1.14.5"
 solana-client = "1.14.5"

--- a/README.md
+++ b/README.md
@@ -2,26 +2,54 @@
 
 ## Commands
 
-```bash
-lut create 
-```
+### Create
 
 Creates a new LUT using the default keypair in the Solana config file.
 
 ```bash
-lut extend <lut_address> -a <address1> -a <address2> -a <address3>
+lut create 
 ```
+
+---
+
+### Extend
 
 Appends new addresses to the LUT.
 
+From space-separated addresses on the command line:
+
+```bash
+lut extend <lut_address> -a <address1> -a <address2> -a <address3>
+```
+Or from a JSON file with a list of addresses:
+
+```bash
+lut extend <lut_address> -f <path_to_json_file>
+```
+
+---
+
+### Decode
+Decode all current entries in the LUT and print to the command line.
+    
+    ```bash
+    lut decode <lut_address>
+    ```
+
+---
+
+### Deactivate
+Deactivates the LUT, starting the cooldown period.
 ```bash
 lut deactivate <lut_address>
 ```
 
-Deactivates the LUT, starting the cooldown period.
+---
+
+### Close
+Closes the LUT and returns the rent funds to the owner keypair.
+
 
 ```bash
 lut close <lut_address>
 ```
-
-Closes the LUT and returns the rent funds to the owner keypair.

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,8 +19,13 @@ pub enum Commands {
     Extend {
         lut: String,
 
+        /// Space separated list of addresses
         #[arg(short, long, action = ArgAction::Append)]
-        addresses: Vec<String>,
+        addresses: Option<Vec<String>>,
+
+        /// JSON file with list of addresses
+        #[arg(short, long)]
+        file: Option<String>,
     },
     Close {
         lut: String,

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use solana_client::rpc_client::RpcClient;
 use solana_sdk::{
     clock::Slot,
+    commitment_config::CommitmentConfig,
     hash::Hash,
     signature::{read_keypair_file, Keypair},
 };
@@ -29,7 +30,10 @@ impl CliConfig {
         let keypair = read_keypair_file(&config.keypair_path)
             .map_err(|_| anyhow!("Couldn't read keypair file"))?;
 
-        let client = solana_client::rpc_client::RpcClient::new(config.json_rpc_url);
+        let client = solana_client::rpc_client::RpcClient::new_with_commitment(
+            config.json_rpc_url,
+            CommitmentConfig::confirmed(),
+        );
         let recent_blockhash = client.get_latest_blockhash()?;
         let recent_slot = client.get_slot()?;
 


### PR DESCRIPTION
Adds the ability to read new addresses from a JSON file for the `extend` command. Updates the README. Changes the RPC to be set up with `confirmed` instead of `finalized` to speed up transaction confirmation. 